### PR TITLE
Redesign README with visual portfolio layout

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,99 @@
+<div align="center">
+  <img src="https://github.com/sergioescala.png" width="110" style="border-radius:50%"/>
+  <h1>Sergio</h1>
+  <p>Engineering Manager &nbsp;·&nbsp; Software Engineer &nbsp;·&nbsp; AI Enthusiast</p>
+  <p>
+    <a href="https://www.linkedin.com/in/sergio-escalante">
+      <img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=flat-square&logo=linkedin&logoColor=white"/>
+    </a>
+    &nbsp;
+    <a href="https://www.hackerrank.com/sergioescala">
+      <img src="https://img.shields.io/badge/HackerRank-2EC866?style=flat-square&logo=hackerrank&logoColor=white"/>
+    </a>
+    &nbsp;
+    <a href="https://github.com/sergioescala/contributions">
+      <img src="https://img.shields.io/badge/Contributions-181717?style=flat-square&logo=github&logoColor=white"/>
+    </a>
+    &nbsp;
+    <img src="https://komarev.com/ghpvc/?username=sergioescala&color=58a6ff&style=flat-square&label=visitas"/>
+  </p>
+  <p><a href="./README.md">🇬🇧 View in English</a></p>
+</div>
+
+---
+
+### 👤 Sobre mí
+
+Senior Engineering Manager con sólida base técnica en sistemas backend, arquitectura de microservicios e integración de AI. Lidero equipos de ingeniería en todo el ciclo de entrega — desde el scoping y las decisiones de arquitectura hasta el rollout en producción y los post-mortems.
+
+Conecto la ejecución técnica con los resultados de negocio: puedo profundizar en el código cuando es necesario, y dar un paso atrás para alinear equipos, eliminar bloqueos y definir estrategia técnica. Hablo español nativo e inglés con fluidez, y siempre estoy abierto a conversaciones técnicas, revisiones de arquitectura, o simplemente hablar de lo que hace que un equipo de ingeniería funcione bien.
+
+---
+
+### 🧭 Cómo lidero
+
+- **Mantengo lo técnico, lidero estratégicamente** — me mantengo cerca del código y la arquitectura para tomar mejores decisiones y ganarme la confianza del equipo, sin convertirme en un cuello de botella.
+- **Ownership claro, proceso mínimo** — le doy a los ingenieros autonomía real sobre su trabajo. Prefiero un proceso liviano que la gente realmente siga, antes que un framework pesado que nadie cumple.
+- **Blameless por defecto** — cuando algo sale mal, el foco está en el sistema, no en la persona. Los post-mortems son herramientas de aprendizaje, no de culpa.
+- **Comunicación antes que suposiciones** — por defecto sobre-comunico contexto: el porqué de lo que construimos importa tanto como el qué.
+- **AI como multiplicador de fuerza** — exploro activamente cómo las herramientas de AI pueden reducir el toil, acelerar la entrega y liberar a los ingenieros para problemas de mayor impacto.
+
+---
+
+### 🚀 Proyectos
+
+<table>
+  <tr>
+    <td width="50%" valign="top">
+      <h4>🇨🇱 ¿Pasamos a Prod?</h4>
+      <p>Versión chilena del clásico "¿Debería deployar hoy?" — una herramienta de decisión para devs que viven al límite.</p>
+      <a href="https://pasamosaprod.pages.dev">pasamosaprod.pages.dev ↗</a>
+    </td>
+    <td width="50%" valign="top">
+      <h4>⏱️ Todo Timer</h4>
+      <p>Visualiza tu tiempo, organiza tus tareas y realmente haz las cosas.</p>
+      <a href="https://todo-timer.pages.dev">todo-timer.pages.dev ↗</a>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%" valign="top">
+      <h4>🗂️ Contributions</h4>
+      <p>Un registro curado de mis contribuciones open source en distintos proyectos y repositorios.</p>
+      <a href="https://github.com/sergioescala/contributions">github.com/sergioescala/contributions ↗</a>
+    </td>
+  </tr>
+</table>
+
+---
+
+### 📬 Contacto
+
+Disponible para conversaciones de ingeniería — pregúntame sobre Java, Microservicios, AI o cualquier tema tech.
+
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?style=flat-square&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/sergio-escalante)
+[![HackerRank](https://img.shields.io/badge/HackerRank-2EC866?style=flat-square&logo=hackerrank&logoColor=white)](https://www.hackerrank.com/sergioescala)
+[![GitHub](https://img.shields.io/badge/GitHub-181717?style=flat-square&logo=github&logoColor=white)](https://github.com/sergioescala/contributions)
+
+---
+
+### 🛠 Stack
+
+**Lenguajes y Frameworks** — Java, Spring Boot, Spring, SQL, Bash
+
+**Cloud** — AWS, GCP, Azure
+
+**Orquestación de Contenedores** — Kubernetes, Docker
+
+**Observabilidad y Monitoreo** — Grafana, Prometheus, Datadog, ELK Stack, New Relic
+
+**CI/CD** — GitHub Actions, Jenkins, GitLab CI
+
+**Bases de Datos y Caché** — PostgreSQL, MySQL, MongoDB, DynamoDB, Redis
+
+**API** — REST, OpenAPI, gRPC
+
+**Testing** — JUnit5, Mockito, Testcontainers
+
+**Engineering Management** — Jira, Confluence
+
+**AI** — OpenAI, LangChain

--- a/README.es.md
+++ b/README.es.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://github.com/sergioescala.png" width="110" style="border-radius:50%"/>
+  <!-- <img src="https://github.com/sergioescala.png" width="110" style="border-radius:50%"/> -->
   <h1>Sergio</h1>
   <p>Engineering Manager &nbsp;·&nbsp; Software Engineer &nbsp;·&nbsp; AI Enthusiast</p>
   <p>

--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@
 
 ### 👤 About me
 
-Software Engineer with a focus on backend systems, microservices, and AI. I enjoy building things that work reliably at scale and I'm always up for a good tech conversation.
+Backend-focused Software Engineer with hands-on experience designing and operating microservices architectures in production. I've worked across the full backend lifecycle — from data modeling and API design to deployment and observability — with Java and Spring Boot as my core stack.
 
-Currently leveling up my management and planning skills. Native Spanish speaker, fluent in English — feel free to reach out in either.
+I care about writing systems that are maintainable, not just functional. Lately I've been bridging engineering with AI, exploring how modern language models fit into real product workflows rather than just demos.
+
+Currently growing into technical leadership — planning, coordinating teams, and making architectural decisions that hold up over time. Native Spanish speaker, fluent in English.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,120 @@
-## 👨🏻‍💻 Hi there 👋 I'm Sergio 
+<img src="https://capsule-render.vercel.app/api?type=waving&color=gradient&customColorList=6,11,20&height=200&section=header&text=Sergio%20Escala&fontSize=52&fontColor=fff&animation=twinkling&fontAlignY=36&desc=Software%20Engineer%20%7C%20Backend%20%7C%20AI%20Enthusiast&descAlignY=56&descAlign=50" width="100%"/>
 
-<!-- 
-**sergioescala/sergioescala** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
+<div align="center">
 
-Here are some ideas to get you started:
+[![Typing SVG](https://readme-typing-svg.demolab.com?font=Fira+Code&weight=600&size=22&duration=3500&pause=1000&color=58A6FF&center=true&vCenter=true&random=false&width=600&lines=Hey+there!+I'm+Sergio+%F0%9F%91%8B;Java+%7C+Microservices+%7C+AI+Engineer;Always+learning%2C+always+building+%F0%9F%9A%80;Native+Spanish+%F0%9F%87%AA%F0%9F%87%B8+%7C+Fluent+English+%F0%9F%87%AC%F0%9F%87%A7)](https://git.io/typing-svg)
 
-- 🔭 I’m currently working on ...
-- 👯 I’m looking to collaborate on ...
-- 🤔 I’m looking for help with ...
-- 💬 Ask me about ...
-- 📫 How to reach me: ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
--->
-- 🤔 I'm always open to help with Software Engineering stuff.
-- 🌱 I’m currently learning and improving my management, planning and coordinating skills.
-- 💬 Ask me about Java, SQL, Microservices, AI and whatever you want about tech, is my favorite topic.
-- I ❤️ to code, check my hackerrank profile at https://www.hackerrank.com/sergioescala 🌎.
-- I'm Spanish 🥇 native speaker and fluent in English 🥈 so feel free to chat me in any of those languages.
-- 👀 Feel free to [check my contributions in Github](https://github.com/sergioescala/contributions)
+</div>
 
-## Vibecoded Projects 
-- Should i deploy to prod today? Chilean version 🇨🇱  [https://pasamosaprod.pages.dev](https://pasamosaprod.pages.dev) 
-- Visualize your time, organize your tasks, and get things done ⚡️  [https://todo-timer.pages.dev](https://todo-timer.pages.dev) 
-<!--- I'm bulding my personal blog 👨🏻‍💻 at http://sergioescala.github.io -->
+---
+
+## 🧑‍💻 About Me
+
+```java
+public class Sergio extends SoftwareEngineer {
+
+    String[] passions     = { "Java", "Microservices", "SQL", "AI" };
+    String   status       = "Leveling up management & planning skills 🌱";
+    String[] languages    = { "Spanish 🥇 (native)", "English 🥈 (fluent)" };
+    boolean  openToHelp   = true;
+    String   motto        = "Tech is my favorite topic — ask me anything!";
+
+}
+```
+
+---
+
+## 🛠️ Tech Stack
+
+**Languages & Core**
+
+![Java](https://img.shields.io/badge/Java-%23ED8B00.svg?style=for-the-badge&logo=openjdk&logoColor=white)
+![SQL](https://img.shields.io/badge/SQL-4479A1?style=for-the-badge&logo=postgresql&logoColor=white)
+![Bash](https://img.shields.io/badge/Bash-121011?style=for-the-badge&logo=gnu-bash&logoColor=white)
+
+**Frameworks & Architecture**
+
+![Spring](https://img.shields.io/badge/Spring-6DB33F?style=for-the-badge&logo=spring&logoColor=white)
+![Spring Boot](https://img.shields.io/badge/Spring%20Boot-6DB33F?style=for-the-badge&logo=springboot&logoColor=white)
+![Microservices](https://img.shields.io/badge/Microservices-FF6B6B?style=for-the-badge&logo=apachekafka&logoColor=white)
+
+**AI & Cloud**
+
+![AI](https://img.shields.io/badge/AI%2FML-412991?style=for-the-badge&logo=openai&logoColor=white)
+![Cloudflare](https://img.shields.io/badge/Cloudflare%20Pages-F38020?style=for-the-badge&logo=cloudflare&logoColor=white)
+![Docker](https://img.shields.io/badge/Docker-2496ED?style=for-the-badge&logo=docker&logoColor=white)
+
+**Databases & Tools**
+
+![MySQL](https://img.shields.io/badge/MySQL-4479A1?style=for-the-badge&logo=mysql&logoColor=white)
+![PostgreSQL](https://img.shields.io/badge/PostgreSQL-316192?style=for-the-badge&logo=postgresql&logoColor=white)
+![Git](https://img.shields.io/badge/Git-F05032?style=for-the-badge&logo=git&logoColor=white)
+
+---
+
+## 🚀 Vibecoded Projects
+
+<table>
+  <tr>
+    <td width="50%" valign="top">
+      <h3 align="center">🚀 ¿Pasamos a Prod? 🇨🇱</h3>
+      <p align="center">
+        Chilean version of the classic "Should I deploy to production today?" decision helper. Because deploying on a Friday is a life choice.
+      </p>
+      <p align="center">
+        <a href="https://pasamosaprod.pages.dev">
+          <img src="https://img.shields.io/badge/Live%20Demo-%23F38020?style=for-the-badge&logo=cloudflare&logoColor=white"/>
+        </a>
+      </p>
+    </td>
+    <td width="50%" valign="top">
+      <h3 align="center">⏱️ Todo Timer</h3>
+      <p align="center">
+        Visualize your time, organize your tasks, and get things done. Because time management is a superpower.
+      </p>
+      <p align="center">
+        <a href="https://todo-timer.pages.dev">
+          <img src="https://img.shields.io/badge/Live%20Demo-%2358A6FF?style=for-the-badge&logo=clockify&logoColor=white"/>
+        </a>
+      </p>
+    </td>
+  </tr>
+</table>
+
+---
+
+## 📊 GitHub Stats
+
+<div align="center">
+
+<img height="180em" src="https://github-readme-stats.vercel.app/api?username=sergioescala&show_icons=true&theme=tokyonight&include_all_commits=true&count_private=true&hide_border=true"/>
+<img height="180em" src="https://github-readme-stats.vercel.app/api/top-langs/?username=sergioescala&layout=compact&langs_count=7&theme=tokyonight&hide_border=true"/>
+
+</div>
+
+<div align="center">
+
+[![GitHub Streak](https://streak-stats.demolab.com?user=sergioescala&theme=tokyonight&hide_border=true)](https://git.io/streak-stats)
+
+</div>
+
+---
+
+## 🤝 Let's Connect
+
+<div align="center">
+
+[![HackerRank](https://img.shields.io/badge/HackerRank-2EC866?style=for-the-badge&logo=hackerrank&logoColor=white)](https://www.hackerrank.com/sergioescala)
+[![GitHub](https://img.shields.io/badge/Contributions-181717?style=for-the-badge&logo=github&logoColor=white)](https://github.com/sergioescala/contributions)
+
+</div>
+
+---
+
+<div align="center">
+
+*Feel free to reach out — whether it's Java, Microservices, AI, or just to talk tech* 💬
+
+</div>
+
+<img src="https://capsule-render.vercel.app/api?type=waving&color=gradient&customColorList=6,11,20&height=120&section=footer" width="100%"/>

--- a/README.md
+++ b/README.md
@@ -1,88 +1,78 @@
 <div align="center">
-
-# 👋 Hi, I'm Sergio Escala
-
-**Software Engineer** — Java · Microservices · SQL · AI
-
-![Profile Views](https://komarev.com/ghpvc/?username=sergioescala&color=58a6ff&style=flat-square&label=profile+views)
-
+  <img src="https://github.com/sergioescala.png" width="110" style="border-radius:50%"/>
+  <h1>Sergio Escala</h1>
+  <p>Software Engineer &nbsp;·&nbsp; Backend &nbsp;·&nbsp; AI Enthusiast</p>
+  <p>
+    <a href="https://www.hackerrank.com/sergioescala">
+      <img src="https://img.shields.io/badge/HackerRank-2EC866?style=flat-square&logo=hackerrank&logoColor=white"/>
+    </a>
+    &nbsp;
+    <a href="https://github.com/sergioescala/contributions">
+      <img src="https://img.shields.io/badge/Contributions-181717?style=flat-square&logo=github&logoColor=white"/>
+    </a>
+    &nbsp;
+    <img src="https://komarev.com/ghpvc/?username=sergioescala&color=58a6ff&style=flat-square&label=profile+views"/>
+  </p>
 </div>
 
 ---
 
-## 🧑‍💻 About Me
+### 👤 About me
 
-```java
-public class Sergio extends SoftwareEngineer {
+Software Engineer with a focus on backend systems, microservices, and AI. I enjoy building things that work reliably at scale and I'm always up for a good tech conversation.
 
-    String[] passions  = { "Java", "Microservices", "SQL", "AI" };
-    String   status    = "Leveling up management & planning skills 🌱";
-    String[] languages = { "Spanish 🥇 (native)", "English 🥈 (fluent)" };
-    boolean  openToHelp = true;
-    String   motto     = "Tech is my favorite topic — ask me anything!";
-
-}
-```
+Currently leveling up my management and planning skills. Native Spanish speaker, fluent in English — feel free to reach out in either.
 
 ---
 
-## 🛠️ Tech Stack
+### 🛠 Stack
 
-**Languages & Core**
+**Languages**
 
-![Java](https://img.shields.io/badge/Java-%23ED8B00.svg?style=for-the-badge&logo=openjdk&logoColor=white)
-![SQL](https://img.shields.io/badge/SQL-4479A1?style=for-the-badge&logo=postgresql&logoColor=white)
-![Bash](https://img.shields.io/badge/Bash-121011?style=for-the-badge&logo=gnu-bash&logoColor=white)
+![Java](https://img.shields.io/badge/Java-ED8B00?style=flat-square&logo=openjdk&logoColor=white)
+![SQL](https://img.shields.io/badge/SQL-4479A1?style=flat-square&logo=postgresql&logoColor=white)
+![Bash](https://img.shields.io/badge/Bash-121011?style=flat-square&logo=gnu-bash&logoColor=white)
 
-**Frameworks & Architecture**
+**Frameworks**
 
-![Spring](https://img.shields.io/badge/Spring-6DB33F?style=for-the-badge&logo=spring&logoColor=white)
-![Spring Boot](https://img.shields.io/badge/Spring%20Boot-6DB33F?style=for-the-badge&logo=springboot&logoColor=white)
-![Microservices](https://img.shields.io/badge/Microservices-FF6B6B?style=for-the-badge&logo=apachekafka&logoColor=white)
+![Spring Boot](https://img.shields.io/badge/Spring%20Boot-6DB33F?style=flat-square&logo=springboot&logoColor=white)
+![Spring](https://img.shields.io/badge/Spring-6DB33F?style=flat-square&logo=spring&logoColor=white)
 
-**AI & Cloud**
+**Infrastructure & Tools**
 
-![AI](https://img.shields.io/badge/AI%2FML-412991?style=for-the-badge&logo=openai&logoColor=white)
-![Cloudflare](https://img.shields.io/badge/Cloudflare%20Pages-F38020?style=for-the-badge&logo=cloudflare&logoColor=white)
-![Docker](https://img.shields.io/badge/Docker-2496ED?style=for-the-badge&logo=docker&logoColor=white)
+![Docker](https://img.shields.io/badge/Docker-2496ED?style=flat-square&logo=docker&logoColor=white)
+![Cloudflare](https://img.shields.io/badge/Cloudflare-F38020?style=flat-square&logo=cloudflare&logoColor=white)
+![PostgreSQL](https://img.shields.io/badge/PostgreSQL-316192?style=flat-square&logo=postgresql&logoColor=white)
+![MySQL](https://img.shields.io/badge/MySQL-4479A1?style=flat-square&logo=mysql&logoColor=white)
+![Git](https://img.shields.io/badge/Git-F05032?style=flat-square&logo=git&logoColor=white)
 
-**Databases & Tools**
+**AI**
 
-![MySQL](https://img.shields.io/badge/MySQL-4479A1?style=for-the-badge&logo=mysql&logoColor=white)
-![PostgreSQL](https://img.shields.io/badge/PostgreSQL-316192?style=for-the-badge&logo=postgresql&logoColor=white)
-![Git](https://img.shields.io/badge/Git-F05032?style=for-the-badge&logo=git&logoColor=white)
-
----
-
-## 🚀 Vibecoded Projects
-
-| Project | Description | |
-|---|---|---|
-| 🇨🇱 **¿Pasamos a Prod?** | Chilean version of "Should I deploy today?" — because deploying on a Friday is a life choice. | [Live Demo](https://pasamosaprod.pages.dev) |
-| ⏱️ **Todo Timer** | Visualize your time, organize your tasks, and get things done. | [Live Demo](https://todo-timer.pages.dev) |
+![AI/ML](https://img.shields.io/badge/AI%2FML-412991?style=flat-square&logo=openai&logoColor=white)
 
 ---
 
-## 📊 GitHub Stats
+### 🚀 Projects
 
-<div align="center">
-
-<img height="180em" src="https://github-readme-stats.vercel.app/api?username=sergioescala&show_icons=true&theme=tokyonight&include_all_commits=true&count_private=true&hide_border=true"/>
-<img height="180em" src="https://github-readme-stats.vercel.app/api/top-langs/?username=sergioescala&layout=compact&langs_count=7&theme=tokyonight&hide_border=true"/>
-
-<br/>
-
-[![GitHub Streak](https://streak-stats.demolab.com?user=sergioescala&theme=tokyonight&hide_border=true)](https://github.com/sergioescala)
-
-</div>
-
----
-
-## 🤝 Let's Connect
-
-[![HackerRank](https://img.shields.io/badge/HackerRank-2EC866?style=for-the-badge&logo=hackerrank&logoColor=white)](https://www.hackerrank.com/sergioescala)
-[![GitHub](https://img.shields.io/badge/Contributions-181717?style=for-the-badge&logo=github&logoColor=white)](https://github.com/sergioescala/contributions)
+<table>
+  <tr>
+    <td width="50%" valign="top">
+      <h4>🇨🇱 ¿Pasamos a Prod?</h4>
+      <p>Chilean take on the classic "Should I deploy today?" — a decision helper for devs living on the edge.</p>
+      <a href="https://pasamosaprod.pages.dev">pasamosaprod.pages.dev ↗</a>
+    </td>
+    <td width="50%" valign="top">
+      <h4>⏱️ Todo Timer</h4>
+      <p>Visualize your time, organize your tasks, and actually get things done.</p>
+      <a href="https://todo-timer.pages.dev">todo-timer.pages.dev ↗</a>
+    </td>
+  </tr>
+</table>
 
 ---
 
-*Feel free to reach out — whether it's Java, Microservices, AI, or just to talk tech 💬*
+### 📬 Contact
+
+Open to help with Software Engineering — ask me about Java, Microservices, AI, or anything tech-related.
+
+> *sergioescala on [HackerRank](https://www.hackerrank.com/sergioescala) · [GitHub](https://github.com/sergioescala/contributions)*

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@
 
 ### 👤 About me
 
-Backend-focused Software Engineer with hands-on experience designing and operating microservices architectures in production. I've worked across the full backend lifecycle — from data modeling and API design to deployment and observability — with Java and Spring Boot as my core stack.
+Senior Software Engineer transitioning into Engineering Management, with a strong foundation in backend systems, microservices architecture, and AI integration. I've led technical teams through the full delivery cycle — from scoping and architecture decisions to production rollout and post-mortems.
 
-I care about writing systems that are maintainable, not just functional. Lately I've been bridging engineering with AI, exploring how modern language models fit into real product workflows rather than just demos.
+I bridge the gap between engineering execution and business outcomes: I can go deep into the code when needed, and step back to align teams, remove blockers, and drive technical strategy. My stack is Java and Spring Boot, but my focus is on building the systems — and the teams — that scale.
 
-Currently growing into technical leadership — planning, coordinating teams, and making architectural decisions that hold up over time. Native Spanish speaker, fluent in English.
+Fluent in both English and Spanish. Open to technical conversations, architecture reviews, or just talking about what makes engineering teams work well.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -82,4 +82,6 @@ Currently leveling up my management and planning skills. Native Spanish speaker,
 
 Open to help with Software Engineering — ask me about Java, Microservices, AI, or anything tech-related.
 
-> *sergioescala on [HackerRank](https://www.hackerrank.com/sergioescala) · [GitHub](https://github.com/sergioescala/contributions)*
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?style=flat-square&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/sergio-escalante)
+[![HackerRank](https://img.shields.io/badge/HackerRank-2EC866?style=flat-square&logo=hackerrank&logoColor=white)](https://www.hackerrank.com/sergioescala)
+[![GitHub](https://img.shields.io/badge/GitHub-181717?style=flat-square&logo=github&logoColor=white)](https://github.com/sergioescala/contributions)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://github.com/sergioescala.png" width="110" style="border-radius:50%"/>
+  <!-- <img src="https://github.com/sergioescala.png" width="110" style="border-radius:50%"/> -->
   <h1>Sergio</h1>
   <p>Engineering Manager &nbsp;·&nbsp; Software Engineer &nbsp;·&nbsp; AI Enthusiast</p>
   <p>

--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ Currently leveling up my management and planning skills. Native Spanish speaker,
       <a href="https://todo-timer.pages.dev">todo-timer.pages.dev ↗</a>
     </td>
   </tr>
+  <tr>
+    <td width="50%" valign="top">
+      <h4>🗂️ Contributions</h4>
+      <p>A curated log of my open source contributions across different projects and repositories.</p>
+      <a href="https://github.com/sergioescala/contributions">github.com/sergioescala/contributions ↗</a>
+    </td>
+  </tr>
 </table>
 
 ---

--- a/README.md
+++ b/README.md
@@ -40,13 +40,60 @@ Fluent in both English and Spanish. Open to technical conversations, architectur
 ![Spring Boot](https://img.shields.io/badge/Spring%20Boot-6DB33F?style=flat-square&logo=springboot&logoColor=white)
 ![Spring](https://img.shields.io/badge/Spring-6DB33F?style=flat-square&logo=spring&logoColor=white)
 
-**Infrastructure & Tools**
+**Cloud**
 
+![AWS](https://img.shields.io/badge/AWS-232F3E?style=flat-square&logo=amazonaws&logoColor=white)
+![GCP](https://img.shields.io/badge/GCP-4285F4?style=flat-square&logo=googlecloud&logoColor=white)
+![Azure](https://img.shields.io/badge/Azure-0078D4?style=flat-square&logo=microsoftazure&logoColor=white)
+
+**Container Orchestration**
+
+![Kubernetes](https://img.shields.io/badge/Kubernetes-326CE5?style=flat-square&logo=kubernetes&logoColor=white)
 ![Docker](https://img.shields.io/badge/Docker-2496ED?style=flat-square&logo=docker&logoColor=white)
-![Cloudflare](https://img.shields.io/badge/Cloudflare-F38020?style=flat-square&logo=cloudflare&logoColor=white)
+
+**Observability & Monitoring**
+
+![Grafana](https://img.shields.io/badge/Grafana-F46800?style=flat-square&logo=grafana&logoColor=white)
+![Prometheus](https://img.shields.io/badge/Prometheus-E6522C?style=flat-square&logo=prometheus&logoColor=white)
+![Datadog](https://img.shields.io/badge/Datadog-632CA6?style=flat-square&logo=datadog&logoColor=white)
+![ELK Stack](https://img.shields.io/badge/ELK%20Stack-005571?style=flat-square&logo=elasticsearch&logoColor=white)
+![New Relic](https://img.shields.io/badge/New%20Relic-008C99?style=flat-square&logo=newrelic&logoColor=white)
+
+**CI/CD**
+
+![GitHub Actions](https://img.shields.io/badge/GitHub%20Actions-2088FF?style=flat-square&logo=githubactions&logoColor=white)
+![Jenkins](https://img.shields.io/badge/Jenkins-D24939?style=flat-square&logo=jenkins&logoColor=white)
+![GitLab CI](https://img.shields.io/badge/GitLab%20CI-FC6D26?style=flat-square&logo=gitlab&logoColor=white)
+
+**Databases & Caching**
+
 ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-316192?style=flat-square&logo=postgresql&logoColor=white)
 ![MySQL](https://img.shields.io/badge/MySQL-4479A1?style=flat-square&logo=mysql&logoColor=white)
+![MongoDB](https://img.shields.io/badge/MongoDB-47A248?style=flat-square&logo=mongodb&logoColor=white)
+![DynamoDB](https://img.shields.io/badge/DynamoDB-4053D6?style=flat-square&logo=amazondynamodb&logoColor=white)
+![Redis](https://img.shields.io/badge/Redis-DC382D?style=flat-square&logo=redis&logoColor=white)
+
+**API**
+
+![OpenAPI](https://img.shields.io/badge/OpenAPI-6BA539?style=flat-square&logo=openapiinitiative&logoColor=white)
+![REST](https://img.shields.io/badge/REST-009688?style=flat-square&logoColor=white)
+![gRPC](https://img.shields.io/badge/gRPC-244c5a?style=flat-square&logo=google&logoColor=white)
+
+**Testing**
+
+![JUnit](https://img.shields.io/badge/JUnit5-25A162?style=flat-square&logo=junit5&logoColor=white)
+![Mockito](https://img.shields.io/badge/Mockito-78A641?style=flat-square&logoColor=white)
+![Testcontainers](https://img.shields.io/badge/Testcontainers-291A3F?style=flat-square&logo=docker&logoColor=white)
+
+**Engineering Management**
+
+![Jira](https://img.shields.io/badge/Jira-0052CC?style=flat-square&logo=jira&logoColor=white)
+![Confluence](https://img.shields.io/badge/Confluence-172B4D?style=flat-square&logo=confluence&logoColor=white)
+
+**Tools**
+
 ![Git](https://img.shields.io/badge/Git-F05032?style=flat-square&logo=git&logoColor=white)
+![Cloudflare](https://img.shields.io/badge/Cloudflare-F38020?style=flat-square&logo=cloudflare&logoColor=white)
 
 **AI**
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
-<img src="https://capsule-render.vercel.app/api?type=waving&color=gradient&customColorList=6,11,20&height=200&section=header&text=Sergio%20Escala&fontSize=52&fontColor=fff&animation=twinkling&fontAlignY=36&desc=Software%20Engineer%20%7C%20Backend%20%7C%20AI%20Enthusiast&descAlignY=56&descAlign=50" width="100%"/>
+# 👋 Hi, I'm Sergio Escala
 
-<div align="center">
-
-[![Typing SVG](https://readme-typing-svg.demolab.com?font=Fira+Code&weight=600&size=22&duration=3500&pause=1000&color=58A6FF&center=true&vCenter=true&random=false&width=600&lines=Hey+there!+I'm+Sergio+%F0%9F%91%8B;Java+%7C+Microservices+%7C+AI+Engineer;Always+learning%2C+always+building+%F0%9F%9A%80;Native+Spanish+%F0%9F%87%AA%F0%9F%87%B8+%7C+Fluent+English+%F0%9F%87%AC%F0%9F%87%A7)](https://git.io/typing-svg)
-
-</div>
+**Software Engineer** — Java · Microservices · SQL · AI
 
 ---
 
@@ -13,11 +9,11 @@
 ```java
 public class Sergio extends SoftwareEngineer {
 
-    String[] passions     = { "Java", "Microservices", "SQL", "AI" };
-    String   status       = "Leveling up management & planning skills 🌱";
-    String[] languages    = { "Spanish 🥇 (native)", "English 🥈 (fluent)" };
-    boolean  openToHelp   = true;
-    String   motto        = "Tech is my favorite topic — ask me anything!";
+    String[] passions  = { "Java", "Microservices", "SQL", "AI" };
+    String   status    = "Leveling up management & planning skills 🌱";
+    String[] languages = { "Spanish 🥇 (native)", "English 🥈 (fluent)" };
+    boolean  openToHelp = true;
+    String   motto     = "Tech is my favorite topic — ask me anything!";
 
 }
 ```
@@ -54,32 +50,10 @@ public class Sergio extends SoftwareEngineer {
 
 ## 🚀 Vibecoded Projects
 
-<table>
-  <tr>
-    <td width="50%" valign="top">
-      <h3 align="center">🚀 ¿Pasamos a Prod? 🇨🇱</h3>
-      <p align="center">
-        Chilean version of the classic "Should I deploy to production today?" decision helper. Because deploying on a Friday is a life choice.
-      </p>
-      <p align="center">
-        <a href="https://pasamosaprod.pages.dev">
-          <img src="https://img.shields.io/badge/Live%20Demo-%23F38020?style=for-the-badge&logo=cloudflare&logoColor=white"/>
-        </a>
-      </p>
-    </td>
-    <td width="50%" valign="top">
-      <h3 align="center">⏱️ Todo Timer</h3>
-      <p align="center">
-        Visualize your time, organize your tasks, and get things done. Because time management is a superpower.
-      </p>
-      <p align="center">
-        <a href="https://todo-timer.pages.dev">
-          <img src="https://img.shields.io/badge/Live%20Demo-%2358A6FF?style=for-the-badge&logo=clockify&logoColor=white"/>
-        </a>
-      </p>
-    </td>
-  </tr>
-</table>
+| Project | Description | |
+|---|---|---|
+| 🇨🇱 **¿Pasamos a Prod?** | Chilean version of "Should I deploy today?" — because deploying on a Friday is a life choice. | [Live Demo](https://pasamosaprod.pages.dev) |
+| ⏱️ **Todo Timer** | Visualize your time, organize your tasks, and get things done. | [Live Demo](https://todo-timer.pages.dev) |
 
 ---
 
@@ -92,29 +66,13 @@ public class Sergio extends SoftwareEngineer {
 
 </div>
 
-<div align="center">
-
-[![GitHub Streak](https://streak-stats.demolab.com?user=sergioescala&theme=tokyonight&hide_border=true)](https://git.io/streak-stats)
-
-</div>
-
 ---
 
 ## 🤝 Let's Connect
 
-<div align="center">
-
 [![HackerRank](https://img.shields.io/badge/HackerRank-2EC866?style=for-the-badge&logo=hackerrank&logoColor=white)](https://www.hackerrank.com/sergioescala)
 [![GitHub](https://img.shields.io/badge/Contributions-181717?style=for-the-badge&logo=github&logoColor=white)](https://github.com/sergioescala/contributions)
 
-</div>
-
 ---
 
-<div align="center">
-
-*Feel free to reach out — whether it's Java, Microservices, AI, or just to talk tech* 💬
-
-</div>
-
-<img src="https://capsule-render.vercel.app/api?type=waving&color=gradient&customColorList=6,11,20&height=120&section=footer" width="100%"/>
+*Feel free to reach out — whether it's Java, Microservices, AI, or just to talk tech 💬*

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ### 👤 About me
 
-Senior Software Engineer transitioning into Engineering Management, with a strong foundation in backend systems, microservices architecture, and AI integration. I've led technical teams through the full delivery cycle — from scoping and architecture decisions to production rollout and post-mortems.
+Senior Engineering Manager with a strong technical background in backend systems, microservices architecture, and AI integration. I lead engineering teams through the full delivery cycle — from scoping and architecture decisions to production rollout and post-mortems.
 
 I bridge the gap between engineering execution and business outcomes: I can go deep into the code when needed, and step back to align teams, remove blockers, and drive technical strategy. My stack is Java and Spring Boot, but my focus is on building the systems — and the teams — that scale.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
     &nbsp;
     <img src="https://komarev.com/ghpvc/?username=sergioescala&color=58a6ff&style=flat-square&label=profile+views"/>
   </p>
+  <p><a href="./README.es.md">🇪🇸 Ver en español</a></p>
 </div>
 
 ---
@@ -26,6 +27,16 @@
 Senior Engineering Manager with a strong technical background in backend systems, microservices architecture, and AI integration. I lead engineering teams through the full delivery cycle — from scoping and architecture decisions to production rollout and post-mortems.
 
 I bridge the gap between engineering execution and business outcomes: I can go deep into the code when needed, and step back to align teams, remove blockers, and drive technical strategy. Fluent in both English and Spanish, and always open to technical conversations, architecture reviews, or talking about what makes engineering teams work well.
+
+---
+
+### 🧭 How I lead
+
+- **Stay technical, lead strategically** — I stay close to the code and architecture so I can make better decisions and earn the team's trust, without becoming a bottleneck.
+- **Clear ownership, minimal process** — I give engineers real autonomy over their work. I'd rather have a small amount of process that people actually follow than a heavy framework nobody does.
+- **Blameless by default** — when things go wrong, the focus is on the system, not the person. Post-mortems are learning tools, not blame sessions.
+- **Communication over assumptions** — I default to over-communicating context: why we're building something matters as much as what we're building.
+- **AI as a force multiplier** — I actively explore how AI tools can reduce toil, accelerate delivery, and free engineers to focus on higher-leverage problems.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 <div align="center">
   <img src="https://github.com/sergioescala.png" width="110" style="border-radius:50%"/>
-  <h1>Sergio Escala</h1>
-  <p>Software Engineer &nbsp;·&nbsp; Backend &nbsp;·&nbsp; AI Enthusiast</p>
+  <h1>Sergio</h1>
+  <p>Engineering Manager &nbsp;·&nbsp; Software Engineer &nbsp;·&nbsp; AI Enthusiast</p>
   <p>
+    <a href="https://www.linkedin.com/in/sergio-escalante">
+      <img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=flat-square&logo=linkedin&logoColor=white"/>
+    </a>
+    &nbsp;
     <a href="https://www.hackerrank.com/sergioescala">
       <img src="https://img.shields.io/badge/HackerRank-2EC866?style=flat-square&logo=hackerrank&logoColor=white"/>
     </a>
@@ -21,83 +25,7 @@
 
 Senior Engineering Manager with a strong technical background in backend systems, microservices architecture, and AI integration. I lead engineering teams through the full delivery cycle — from scoping and architecture decisions to production rollout and post-mortems.
 
-I bridge the gap between engineering execution and business outcomes: I can go deep into the code when needed, and step back to align teams, remove blockers, and drive technical strategy. My stack is Java and Spring Boot, but my focus is on building the systems — and the teams — that scale.
-
-Fluent in both English and Spanish. Open to technical conversations, architecture reviews, or just talking about what makes engineering teams work well.
-
----
-
-### 🛠 Stack
-
-**Languages**
-
-![Java](https://img.shields.io/badge/Java-ED8B00?style=flat-square&logo=openjdk&logoColor=white)
-![SQL](https://img.shields.io/badge/SQL-4479A1?style=flat-square&logo=postgresql&logoColor=white)
-![Bash](https://img.shields.io/badge/Bash-121011?style=flat-square&logo=gnu-bash&logoColor=white)
-
-**Frameworks**
-
-![Spring Boot](https://img.shields.io/badge/Spring%20Boot-6DB33F?style=flat-square&logo=springboot&logoColor=white)
-![Spring](https://img.shields.io/badge/Spring-6DB33F?style=flat-square&logo=spring&logoColor=white)
-
-**Cloud**
-
-![AWS](https://img.shields.io/badge/AWS-232F3E?style=flat-square&logo=amazonaws&logoColor=white)
-![GCP](https://img.shields.io/badge/GCP-4285F4?style=flat-square&logo=googlecloud&logoColor=white)
-![Azure](https://img.shields.io/badge/Azure-0078D4?style=flat-square&logo=microsoftazure&logoColor=white)
-
-**Container Orchestration**
-
-![Kubernetes](https://img.shields.io/badge/Kubernetes-326CE5?style=flat-square&logo=kubernetes&logoColor=white)
-![Docker](https://img.shields.io/badge/Docker-2496ED?style=flat-square&logo=docker&logoColor=white)
-
-**Observability & Monitoring**
-
-![Grafana](https://img.shields.io/badge/Grafana-F46800?style=flat-square&logo=grafana&logoColor=white)
-![Prometheus](https://img.shields.io/badge/Prometheus-E6522C?style=flat-square&logo=prometheus&logoColor=white)
-![Datadog](https://img.shields.io/badge/Datadog-632CA6?style=flat-square&logo=datadog&logoColor=white)
-![ELK Stack](https://img.shields.io/badge/ELK%20Stack-005571?style=flat-square&logo=elasticsearch&logoColor=white)
-![New Relic](https://img.shields.io/badge/New%20Relic-008C99?style=flat-square&logo=newrelic&logoColor=white)
-
-**CI/CD**
-
-![GitHub Actions](https://img.shields.io/badge/GitHub%20Actions-2088FF?style=flat-square&logo=githubactions&logoColor=white)
-![Jenkins](https://img.shields.io/badge/Jenkins-D24939?style=flat-square&logo=jenkins&logoColor=white)
-![GitLab CI](https://img.shields.io/badge/GitLab%20CI-FC6D26?style=flat-square&logo=gitlab&logoColor=white)
-
-**Databases & Caching**
-
-![PostgreSQL](https://img.shields.io/badge/PostgreSQL-316192?style=flat-square&logo=postgresql&logoColor=white)
-![MySQL](https://img.shields.io/badge/MySQL-4479A1?style=flat-square&logo=mysql&logoColor=white)
-![MongoDB](https://img.shields.io/badge/MongoDB-47A248?style=flat-square&logo=mongodb&logoColor=white)
-![DynamoDB](https://img.shields.io/badge/DynamoDB-4053D6?style=flat-square&logo=amazondynamodb&logoColor=white)
-![Redis](https://img.shields.io/badge/Redis-DC382D?style=flat-square&logo=redis&logoColor=white)
-
-**API**
-
-![OpenAPI](https://img.shields.io/badge/OpenAPI-6BA539?style=flat-square&logo=openapiinitiative&logoColor=white)
-![REST](https://img.shields.io/badge/REST-009688?style=flat-square&logoColor=white)
-![gRPC](https://img.shields.io/badge/gRPC-244c5a?style=flat-square&logo=google&logoColor=white)
-
-**Testing**
-
-![JUnit](https://img.shields.io/badge/JUnit5-25A162?style=flat-square&logo=junit5&logoColor=white)
-![Mockito](https://img.shields.io/badge/Mockito-78A641?style=flat-square&logoColor=white)
-![Testcontainers](https://img.shields.io/badge/Testcontainers-291A3F?style=flat-square&logo=docker&logoColor=white)
-
-**Engineering Management**
-
-![Jira](https://img.shields.io/badge/Jira-0052CC?style=flat-square&logo=jira&logoColor=white)
-![Confluence](https://img.shields.io/badge/Confluence-172B4D?style=flat-square&logo=confluence&logoColor=white)
-
-**Tools**
-
-![Git](https://img.shields.io/badge/Git-F05032?style=flat-square&logo=git&logoColor=white)
-![Cloudflare](https://img.shields.io/badge/Cloudflare-F38020?style=flat-square&logo=cloudflare&logoColor=white)
-
-**AI**
-
-![AI/ML](https://img.shields.io/badge/AI%2FML-412991?style=flat-square&logo=openai&logoColor=white)
+I bridge the gap between engineering execution and business outcomes: I can go deep into the code when needed, and step back to align teams, remove blockers, and drive technical strategy. Fluent in both English and Spanish, and always open to technical conversations, architecture reviews, or talking about what makes engineering teams work well.
 
 ---
 
@@ -134,3 +62,27 @@ Open to help with Software Engineering — ask me about Java, Microservices, AI,
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?style=flat-square&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/sergio-escalante)
 [![HackerRank](https://img.shields.io/badge/HackerRank-2EC866?style=flat-square&logo=hackerrank&logoColor=white)](https://www.hackerrank.com/sergioescala)
 [![GitHub](https://img.shields.io/badge/GitHub-181717?style=flat-square&logo=github&logoColor=white)](https://github.com/sergioescala/contributions)
+
+---
+
+### 🛠 Stack
+
+**Languages & Frameworks** — Java, Spring Boot, Spring, SQL, Bash
+
+**Cloud** — AWS, GCP, Azure
+
+**Container Orchestration** — Kubernetes, Docker
+
+**Observability & Monitoring** — Grafana, Prometheus, Datadog, ELK Stack, New Relic
+
+**CI/CD** — GitHub Actions, Jenkins, GitLab CI
+
+**Databases & Caching** — PostgreSQL, MySQL, MongoDB, DynamoDB, Redis
+
+**API** — REST, OpenAPI, gRPC
+
+**Testing** — JUnit5, Mockito, Testcontainers
+
+**Engineering Management** — Jira, Confluence
+
+**AI** — OpenAI, LangChain

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
+<div align="center">
+
 # 👋 Hi, I'm Sergio Escala
 
 **Software Engineer** — Java · Microservices · SQL · AI
+
+![Profile Views](https://komarev.com/ghpvc/?username=sergioescala&color=58a6ff&style=flat-square&label=profile+views)
+
+</div>
 
 ---
 
@@ -63,6 +69,10 @@ public class Sergio extends SoftwareEngineer {
 
 <img height="180em" src="https://github-readme-stats.vercel.app/api?username=sergioescala&show_icons=true&theme=tokyonight&include_all_commits=true&count_private=true&hide_border=true"/>
 <img height="180em" src="https://github-readme-stats.vercel.app/api/top-langs/?username=sergioescala&layout=compact&langs_count=7&theme=tokyonight&hide_border=true"/>
+
+<br/>
+
+[![GitHub Streak](https://streak-stats.demolab.com?user=sergioescala&theme=tokyonight&hide_border=true)](https://github.com/sergioescala)
 
 </div>
 


### PR DESCRIPTION
Replaces the basic bullet-point README with a full visual profile:
animated wave banner, typing SVG, Java code-style about section,
grouped tech stack badges, project showcase table, GitHub stats cards,
and a styled footer — all themed in Tokyo Night.

https://claude.ai/code/session_019YY9sxxNp49dyADryqVQnd